### PR TITLE
[Refactor] header 컴포넌트 부분렌더링

### DIFF
--- a/frontend/src/components/Header/index.js
+++ b/frontend/src/components/Header/index.js
@@ -21,13 +21,23 @@ export default class Header extends Component {
   }
 
   didMount() {
+    this.$year = this.$element.querySelector('.month-controller-year');
+    this.$month = this.$element.querySelector('.month-controller-month');
+
+    store.subscribe(SELECTOR_MAP.CURRENT_DATE, this.refetchDate.bind(this));
+
     this.$element.addEventListener('click', (e) => {
       const { month } = store.getState(SELECTOR_MAP.CURRENT_DATE);
       const $prev = e.target.closest('button');
       const nextMonth = $prev.className === 'month-controller__prev' ? month - 1 : month + 1;
       store.dispatch('updateMonth', nextMonth, SELECTOR_MAP.CURRENT_DATE);
     });
-    store.subscribe(SELECTOR_MAP.CURRENT_DATE, this.render.bind(this));
+  }
+
+  refetchDate() {
+    const { year, month } = store.getState(SELECTOR_MAP.CURRENT_DATE);
+    this.$year.innerText = year;
+    this.$month.innerText = `${month} 월`;
   }
 
   template() {
@@ -39,8 +49,8 @@ export default class Header extends Component {
             <img src="${leftArrowIcon}">
           </button>
           <div>
-            <div class="month-controller-year">${month} 월</div>
-            <div class="month-controller-month">${year}</div>
+            <div class="month-controller-month">${month} 월</div>
+            <div class="month-controller-year">${year}</div>
           </div> 
           <button class="month-controller__next">
             <img src="${rightArrowIcon}">

--- a/frontend/src/components/Header/index.js
+++ b/frontend/src/components/Header/index.js
@@ -1,70 +1,34 @@
 import './index.scss';
 
-import { SELECTOR_MAP } from '@/constants/selector-map';
-import store from '@/store';
-
-import Component from '@/lib/component';
 import fileTextIcon from '@/assets/icon/file-text.svg';
 import calendarIcon from '@/assets/icon/calendar.svg';
 import chartIcon from '@/assets/icon/chart.svg';
-import leftArrowIcon from '@/assets/icon/left-arrow.svg';
-import rightArrowIcon from '@/assets/icon/right-arrow.svg';
 
-export default class Header extends Component {
-  constructor($target, initialState) {
-    super($target);
-  }
-  //store.subscribe('month', this.render.bind(this));
-  init() {
-    this.$element = document.createElement('div');
-    this.$element.className = 'header';
-  }
+import MonthController from './monthController';
 
-  didMount() {
-    this.$year = this.$element.querySelector('.month-controller-year');
-    this.$month = this.$element.querySelector('.month-controller-month');
-
-    store.subscribe(SELECTOR_MAP.CURRENT_DATE, this.refetchDate.bind(this));
-
-    this.$element.addEventListener('click', (e) => {
-      const { month } = store.getState(SELECTOR_MAP.CURRENT_DATE);
-      const $prev = e.target.closest('button');
-      const nextMonth = $prev.className === 'month-controller__prev' ? month - 1 : month + 1;
-      store.dispatch('updateMonth', nextMonth, SELECTOR_MAP.CURRENT_DATE);
-    });
-  }
-
-  refetchDate() {
-    const { year, month } = store.getState(SELECTOR_MAP.CURRENT_DATE);
-    this.$year.innerText = year;
-    this.$month.innerText = `${month} 월`;
+export default class Header {
+  constructor($target) {
+    this.$target = $target;
+    this.render();
   }
 
   template() {
-    const { year, month } = store.getState(SELECTOR_MAP.CURRENT_DATE);
     return `
-        <a is="my-anchor" href="/" class="header-title" >우아한 가계부</a> 
-        <div class="month-controller">
-          <button class="month-controller__prev">
-            <img src="${leftArrowIcon}">
-          </button>
-          <div>
-            <div class="month-controller-month">${month} 월</div>
-            <div class="month-controller-year">${year}</div>
-          </div> 
-          <button class="month-controller__next">
-            <img src="${rightArrowIcon}">
-          </button>
-        </div>
+      <div class="header">
+        <a is="my-anchor" href="/" class="header-title" >우아한 가계부</a>
+        <div class="month-controller" ></div>
         <div class='nav'>
           <a class="nav-main" is="my-anchor" href="/"><img src="${fileTextIcon}"></a> 
           <a class="nav-calendar" is="my-anchor" href="/calendar"><img src="${calendarIcon}"></a>
           <a class="nav-statistic" is="my-anchor" href="/statistic"><img src="${chartIcon}"></a>
         </div>
-    `;
+      </div>
+  `;
   }
+
   render() {
-    this.$element.innerHTML = this.template();
-    this.$target.appendChild(this.$element);
+    this.$target.innerHTML = this.template();
+    const $monthController = this.$target.querySelector('.month-controller');
+    new MonthController($monthController);
   }
 }

--- a/frontend/src/components/Header/index.scss
+++ b/frontend/src/components/Header/index.scss
@@ -6,7 +6,6 @@
   padding: 2rem 8em;
   background-color: $color-beamin;
   color: $color-white;
-
   .header-title {
     font-size: 1.5rem;
     font-weight: 600;
@@ -31,14 +30,11 @@
     margin: 0 1.2rem;
   }
   .month-controller-year {
-    font-size: 2rem;
-    font-weight: 600;
-  }
-  .month-controller-month {
     margin-top: 0.3rem;
     font-size: 1.2rem;
   }
-}
-
-.nav-main {
+  .month-controller-month {
+    font-size: 2rem;
+    font-weight: 600;
+  }
 }

--- a/frontend/src/components/Header/monthController.js
+++ b/frontend/src/components/Header/monthController.js
@@ -1,0 +1,55 @@
+import './index.scss';
+
+import { SELECTOR_MAP } from '@/constants/selector-map';
+import store from '@/store';
+import leftArrowIcon from '@/assets/icon/left-arrow.svg';
+import rightArrowIcon from '@/assets/icon/right-arrow.svg';
+import Component from '@/lib/component';
+
+export default class MonthController extends Component {
+  constructor($target) {
+    super($target);
+    this.$target = $target;
+  }
+
+  didMount() {
+    this.$year = this.$target.querySelector('.month-controller-year');
+    this.$month = this.$target.querySelector('.month-controller-month');
+
+    store.subscribe(SELECTOR_MAP.CURRENT_DATE, this.refetchDate.bind(this));
+
+    this.$target.addEventListener('click', (e) => {
+      const { month } = store.getState(SELECTOR_MAP.CURRENT_DATE);
+      const $prev = e.target.closest('button');
+      if (!$prev) return;
+      const nextMonth = $prev.className === 'month-controller__prev' ? month - 1 : month + 1;
+      store.dispatch('updateMonth', nextMonth, SELECTOR_MAP.CURRENT_DATE);
+    });
+  }
+
+  refetchDate() {
+    const { year, month } = store.getState(SELECTOR_MAP.CURRENT_DATE);
+    this.$year.innerText = year;
+    this.$month.innerText = `${month} 월`;
+  }
+
+  template() {
+    const { year, month } = store.getState(SELECTOR_MAP.CURRENT_DATE);
+    return `
+        <button class="month-controller__prev">
+            <img src="${leftArrowIcon}">
+        </button>
+        <div>
+            <div class="month-controller-month">${month} 월</div>
+            <div class="month-controller-year">${year}</div>
+        </div> 
+        <button class="month-controller__next">
+            <img src="${rightArrowIcon}">
+        </button>
+    `;
+  }
+
+  render() {
+    this.$target.innerHTML = this.template();
+  }
+}

--- a/frontend/src/components/Header/monthController.js
+++ b/frontend/src/components/Header/monthController.js
@@ -15,16 +15,16 @@ export default class MonthController extends Component {
   didMount() {
     this.$year = this.$target.querySelector('.month-controller-year');
     this.$month = this.$target.querySelector('.month-controller-month');
-
     store.subscribe(SELECTOR_MAP.CURRENT_DATE, this.refetchDate.bind(this));
+    this.$target.addEventListener('click', (e) => this.changeMonth);
+  }
 
-    this.$target.addEventListener('click', (e) => {
-      const { month } = store.getState(SELECTOR_MAP.CURRENT_DATE);
-      const $prev = e.target.closest('button');
-      if (!$prev) return;
-      const nextMonth = $prev.className === 'month-controller__prev' ? month - 1 : month + 1;
-      store.dispatch('updateMonth', nextMonth, SELECTOR_MAP.CURRENT_DATE);
-    });
+  changeMonth() {
+    const { month } = store.getState(SELECTOR_MAP.CURRENT_DATE);
+    const $prev = e.target.closest('button');
+    if (!$prev) return;
+    const nextMonth = $prev.className === 'month-controller__prev' ? month - 1 : month + 1;
+    store.dispatch('updateMonth', nextMonth, SELECTOR_MAP.CURRENT_DATE);
   }
 
   refetchDate() {

--- a/frontend/src/components/Header/monthController.js
+++ b/frontend/src/components/Header/monthController.js
@@ -9,17 +9,17 @@ import Component from '@/lib/component';
 export default class MonthController extends Component {
   constructor($target) {
     super($target);
-    this.$target = $target;
   }
 
   didMount() {
     this.$year = this.$target.querySelector('.month-controller-year');
     this.$month = this.$target.querySelector('.month-controller-month');
+    this.refetchDate();
     store.subscribe(SELECTOR_MAP.CURRENT_DATE, this.refetchDate.bind(this));
-    this.$target.addEventListener('click', (e) => this.changeMonth);
+    this.$target.addEventListener('click', this.changeMonth);
   }
 
-  changeMonth() {
+  changeMonth(e) {
     const { month } = store.getState(SELECTOR_MAP.CURRENT_DATE);
     const $prev = e.target.closest('button');
     if (!$prev) return;
@@ -34,14 +34,13 @@ export default class MonthController extends Component {
   }
 
   template() {
-    const { year, month } = store.getState(SELECTOR_MAP.CURRENT_DATE);
     return `
         <button class="month-controller__prev">
             <img src="${leftArrowIcon}">
         </button>
         <div>
-            <div class="month-controller-month">${month} 월</div>
-            <div class="month-controller-year">${year}</div>
+            <div class="month-controller-month"></div>
+            <div class="month-controller-year"></div>
         </div> 
         <button class="month-controller__next">
             <img src="${rightArrowIcon}">


### PR DESCRIPTION
* Closes #24

## ✨ 구현 기능 명세
* monthController 컴포넌트 분리
* 년도, 월만 재랜더링 해주는 refetchDate 함수 추가 후 구독 listener 변경
## 🎁 PR Point
* 저희가 header 컴포넌트 부분렌더링 때문에 두가지 안을 냈었는데 직접 적용해보니까 둘 다 작업하는게 맞는거 같더라구요 ㅎㅎ 컴포넌트를 분리해도 refetchDate 함수가 필요하고, monthController가 가진 역할 때문에 컴포넌트 분리하는 것도 맞는거 같아요 
* 문서작업을 미루지 않기 위해서 wiki에도 결론 적어놨습니다
## 😭 어려웠던 점
* 이건 어렵다기 보다는 고민인데 현재  monthController 컴포넌트를 Header 폴더안에 넣어놨는데, monthController가 Header컴포넌트에 종속적이니까 Header에 들어가는게 맞는지 monthController를 위한 폴더를 만드는게 맞는지 디렉토리 구조 부분에서 고민이 듭니다 :)
## ⏰ 실제 소요 시간 
1.5h